### PR TITLE
Include other elements

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,14 +1,6 @@
-[76Ge_0vbb]
-git-tree-sha1 = "762f23229b4be70e6e5a65744cd63e6e83eae8b4"
+[KotilaIachello2012]
+git-tree-sha1 = "23ef8990cdc5f6c1bc253d5176ae9fd9be3c1a2f"
 
-    [[76Ge_0vbb.download]]
-    url = "https://raw.githubusercontent.com/Yuan-Ru-Lin/DoubleBetaDecaysArtifacts/main/76Ge_0vbb.tar.gz"
-    sha256 = "83bf36e9a0ed23c8c97a67cd8b9a7fd76cb0f1ccdf328afca25aa77831e411be"
-
-[76Ge_2vbb]
-git-tree-sha1 = "83e701fe36d459b06b6f55b0f10d071d93618fbf"
-
-    [[76Ge_2vbb.download]]
-    url = "https://raw.githubusercontent.com/Yuan-Ru-Lin/DoubleBetaDecaysArtifacts/main/76Ge_2vbb.tar.gz"
-    sha256 = "6bbac0a31f8eafe16a26a610ea2b293db11ee7c49b4420fa6ff94e846a5f4d6a"
-
+    [[KotilaIachello2012.download]]
+    url = "https://github.com/Yuan-Ru-Lin/DoubleBetaDecaysArtifacts/releases/download/v0.0.1/KotilaIachello2012.tar.gz"
+    sha256 = "513d8654a6a65660773145bd26d67197660c11071e935f1ce9d748d8ec8b9fd7"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,6 +1,6 @@
 [KotilaIachello2012]
-git-tree-sha1 = "23ef8990cdc5f6c1bc253d5176ae9fd9be3c1a2f"
+git-tree-sha1 = "4d2a715b8f1e729c1c8ff4d808340735cd8028b3"
 
     [[KotilaIachello2012.download]]
-    url = "https://github.com/Yuan-Ru-Lin/DoubleBetaDecaysArtifacts/releases/download/v0.0.1/KotilaIachello2012.tar.gz"
-    sha256 = "513d8654a6a65660773145bd26d67197660c11071e935f1ce9d748d8ec8b9fd7"
+    url = "https://github.com/Yuan-Ru-Lin/DoubleBetaDecaysArtifacts/releases/download/v0.0.2/KotilaIachello2012.tar.gz"
+    sha256 = "1548f0a2fe215dc9af888d8c8f1ebb255ef95919fa7b27a6326fa2e8776aaa8c"

--- a/docs/src/examples/plots.jl
+++ b/docs/src/examples/plots.jl
@@ -1,30 +1,43 @@
 # # Energy Distributions at Generator level
 
-# In this example, we will generate 1 million events for each decay mode and plot the summed electron energy spectra as sanity checks.
+# In this example, we will generate 1 million events for ``2\nu`` and ``0\nu`` decays of ``^{76}\textrm{Ge}`` and plot summed electron energy spectra as sanity checks.
 
 using DoubleBetaDecayGenerators
-using Artifacts
 using FHist
 using CairoMakie
 
-# Note that the data files needed for the generators are handled automatically via the Artifacts API. Also note that the generators, at the moment, can only be of ``^{76}\rm{Ge}``.
+dat_0nu = ZeroNuDBDData(:Ge76)
+dat_2nu = TwoNuDBDData(:Ge76);
 
-dat_0nu = ZeroNuDBDData(joinpath(artifact"KotilaIachello2012", "76Ge"))
-dat_2nu = TwoNuDBDData(joinpath(artifact"KotilaIachello2012", "76Ge"))
+# Note that the data files needed for the generators are handled automatically via Artifacts API.
 
 energies_0nu = [
     let (E1, E2, cosθ12) = rand(dat_0nu)
-        E1 + E2
+            E1 + E2
     end for i in 1:1_000_000
 ]
 energies_2nu = [
     let (E1, E2, cosθ12) = rand(dat_2nu)
-        E1 + E2
+            E1 + E2
     end for i in 1:1_000_000
 ]
 
-stephist(Hist1D(energies_0nu, binedges=0:2040), axis=(; yscale=log10, limits=(nothing,(0.5,10^7)), xlabel=L"$E_1$ + $E_2$ [keV]", ylabel="Counts/(1 keV)", title=L"0\nu\beta\beta\;(N=10^6)"))
+stephist(
+    Hist1D(energies_0nu, binedges = 0:2040),
+    axis = (;
+        yscale = log10, limits = (nothing, (0.5, 10^7)),
+        xlabel = L"$E_1$ + $E_2$ [keV]", ylabel = "Counts/(1 keV)",
+        title = L"0\nu\beta\beta\;(N=10^6)",
+    )
+)
 
 # As we expected, the ``0\nu\beta\beta`` spectrum is a peak at the ``Q``-value (2039 keV for ``^{76}\rm{Ge}``), while the ``2\nu\beta\beta`` spectrum is a broad continuum from 0 to the ``Q``-value.
 
-stephist(Hist1D(energies_2nu, binedges=0:2040), axis=(; yscale=log10, limits=(nothing,(0.5,10^4)), xlabel=L"$E_1$ + $E_2$ [keV]", ylabel="Counts/(1 keV)", title=L"2\nu\beta\beta\;(N=10^6)"))
+stephist(
+    Hist1D(energies_2nu, binedges = 0:2040),
+    axis = (;
+        yscale = log10, limits = (nothing, (0.5, 10^4)),
+        xlabel = L"$E_1$ + $E_2$ [keV]", ylabel = "Counts/(1 keV)",
+        title = L"2\nu\beta\beta\;(N=10^6)"
+    )
+)

--- a/docs/src/examples/plots.jl
+++ b/docs/src/examples/plots.jl
@@ -3,13 +3,14 @@
 # In this example, we will generate 1 million events for each decay mode and plot the summed electron energy spectra as sanity checks.
 
 using DoubleBetaDecayGenerators
+using Artifacts
 using FHist
 using CairoMakie
 
 # Note that the data files needed for the generators are handled automatically via the Artifacts API. Also note that the generators, at the moment, can only be of ``^{76}\rm{Ge}``.
 
-dat_0nu = ZeroNuDBDData()
-dat_2nu = TwoNuDBDData()
+dat_0nu = ZeroNuDBDData(joinpath(artifact"KotilaIachello2012", "76Ge"))
+dat_2nu = TwoNuDBDData(joinpath(artifact"KotilaIachello2012", "76Ge"))
 
 energies_0nu = [
     let (E1, E2, cosθ12) = rand(dat_0nu)

--- a/src/DoubleBetaDecayGenerators.jl
+++ b/src/DoubleBetaDecayGenerators.jl
@@ -20,7 +20,13 @@ is the linear angular coefficient.
 """
 acute_inv_cdf(x::Real, q::Real) = (√(q^2 - 2q + 4q*x+1) - 1)/q
 
+const DBD_ISOTOPES::NTuple{19,Symbol} = (
+    :Ca48, :Cd116, :Gd160, :Ge76, :Mo100, :Nd148, :Nd150, :Pd110, :Pt198,
+    :Se82, :Sm154, :Sn124, :Te128, :Te130, :Th232, :U238, :Xe134, :Xe136, :Zr96
+)
 abstract type DBDData end
+abstract type DBDDataSource end
+abstract type KotilaIachello2012 <: DBDDataSource end
 
 """
     ZeroNuDBDData(path)
@@ -34,8 +40,10 @@ struct ZeroNuDBDData <: DBDData
     _cor_data::AbstractArray{Real, 1}
     ses_dist::UvBinnedDist
     Q_value_keV::Real
-    function ZeroNuDBDData(path::AbstractString)
-        @info "Reading raw data from '$path'"
+    function ZeroNuDBDData(isotope::Symbol, datasource::Type{<:DBDDataSource} = KotilaIachello2012)
+        @assert isotope in DBD_ISOTOPES "$isotope does not undergo double-beta decay.\nAvailable isotopes are $DBD_ISOTOPES."
+        @debug "Reading raw data from '$path'"
+        path = @artifact_str("$(nameof(datasource))/$isotope")
 
         _cor_data = readdlm("$path/cor_0v.txt", Float64)[:, 3]
         _ses_data = readdlm("$path/ses_0v.txt", Float64)[:, 3]
@@ -78,8 +86,10 @@ struct TwoNuDBDData <: DBDData
     ses_dist::UvBinnedDist
     tds_dist::MvBinnedDist
 
-    function TwoNuDBDData(path::AbstractString)
-        @info "Reading raw data from '$path'"
+    function TwoNuDBDData(isotope::Symbol, datasource::Type{<:DBDDataSource} = KotilaIachello2012)
+        @assert isotope in DBD_ISOTOPES "$isotope does not undergo double-beta decay.\nAvailable isotopes are $DBD_ISOTOPES."
+        @debug "Reading raw data from '$path'"
+        path = @artifact_str("$(nameof(datasource))/$isotope")
 
         _ses_data = readdlm("$path/ses.txt", Float64)[:, 3]
         e_max_keV = length(_ses_data)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ using Random
 
     Random.seed!(rng, 999)
 
-    dat_2nu = TwoNuDBDData(joinpath(artifact"KotilaIachello2012", "76Ge"))
+    dat_2nu = TwoNuDBDData(:Ge76)
     E1, E2, cosθ12 = rand(rng, dat_2nu)
     @test E1 ≈ 374.2355832686694 atol=1e-15
     @test E2 ≈ 1251.059139039826 atol=1e-15
@@ -16,7 +16,7 @@ using Random
 
     Random.seed!(rng, 999)
 
-    dat_0nu = ZeroNuDBDData(joinpath(artifact"KotilaIachello2012", "76Ge"))
+    dat_0nu = ZeroNuDBDData(:Ge76)
     E1, E2, cosθ12 = rand(rng, dat_0nu)
     @test E1 ≈ 2016.2355832686694 atol=1e-15
     @test E2 ≈ 22.764416731330584 atol=1e-15

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using Test
 using DoubleBetaDecayGenerators
-using Artifacts
 using Random
 
 @testset "Test control of random seed" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Test
 using DoubleBetaDecayGenerators
+using Artifacts
 using Random
 
 @testset "Test control of random seed" begin
@@ -7,7 +8,7 @@ using Random
 
     Random.seed!(rng, 999)
 
-    dat_2nu = TwoNuDBDData()
+    dat_2nu = TwoNuDBDData(joinpath(artifact"KotilaIachello2012", "76Ge"))
     E1, E2, cosθ12 = rand(rng, dat_2nu)
     @test E1 ≈ 374.2355832686694 atol=1e-15
     @test E2 ≈ 1251.059139039826 atol=1e-15
@@ -15,7 +16,7 @@ using Random
 
     Random.seed!(rng, 999)
 
-    dat_0nu = ZeroNuDBDData()
+    dat_0nu = ZeroNuDBDData(joinpath(artifact"KotilaIachello2012", "76Ge"))
     E1, E2, cosθ12 = rand(rng, dat_0nu)
     @test E1 ≈ 2016.2355832686694 atol=1e-15
     @test E2 ≈ 22.764416731330584 atol=1e-15


### PR DESCRIPTION
Right now users are expected to directly use `@artifact_str` to fetch directories where data files live. This is at quite low-level and results in verbose code.

```julia
dat_0nu = ZeroNuDBDData(joinpath(artifact"KotilaIachello2012", "76Ge"))
dat_2nu = TwoNuDBDData(joinpath(artifact"KotilaIachello2012", "76Ge"))
```

Another approach is to define an abstract type for data source and set `KotilaIachello2012` as the default value in constructors of the two concrete types.

```julia
abstract type DBDDataSource end
abstract type KotilaIachello2012 <: DBDDataSource end
```

But I can't write the following in Julia.

```julia
function T(::Type{U} = KotilaIachello2012, isotope::String) where {T<:DBDData, U<:DBDDataSource}
    T(joinpath(@artifact_str(string(U)), isotope))
end
"""
WARNING: method definition for TypeVar at REPL[11]:1 declares type variable T but does not use it.
WARNING: method definition for TypeVar at REPL[11]:1 declares type variable T but does not use it.
T (generic function with 0 methods)
"""
```

I have to either define constructors individually

```julia
function DoubleBetaDecayGenerators.TwoNuDBDData(isotope::Symbol, ::Type{U} = KotilaIachello2012) where {U<:DBDDataSource}
    TwoNuDBDData(joinpath(@artifact_str(string(U)), string(isotope)))
end
function DoubleBetaDecayGenerators.ZeroNuDBDData(isotope::Symbol, ::Type{U} = KotilaIachello2012) where {U<:DBDDataSource}
    ZeroNuDBDData(joinpath(@artifact_str(string(U)), string(isotope)))
end
```

Or build a factory function

```julia
function load_dbd_data(::Type{T}, isotope::Symbol, ::Type{U} = KotilaIachello2012) where {T<:DBDData, U<:DBDDataSource}
    T(joinpath(@artifact_str(string(U)), string(isotope)))
end
```

I must have overlooked something